### PR TITLE
Fix: class name inflection

### DIFF
--- a/lib/materialist/materializer.rb
+++ b/lib/materialist/materializer.rb
@@ -123,7 +123,7 @@ module Materialist
         end
 
         def model_class
-          options.fetch(:model_class).to_s.classify.constantize
+          options.fetch(:model_class).to_s.camelize.constantize
         end
 
         def attributes


### PR DESCRIPTION
`camelize` is the correct inflection, not `classify`. because the latter force-signularizes the string.