### PR TITLE
Make it possible to materialise linked resource without materialising self

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,9 @@ end
 Here is what each part of the DSL mean:
 
 #### `use_model <model_name>`
-describes the name of the active record model to be used.
+describes the name of the active record model to be used.  
+If missing, materialist skips materialising the resource itself, but will continue
+with any other functionality -- such as `materialize_link`.
 
 #### `materialize <key>, as: <column> (default: key)`
 describes mapping a resource key to database column.


### PR DESCRIPTION
### Why

There are times when we are only interested in materialising the linked resource, and not materialising the topic itself.

```ruby
class ZoneSettingMaterializer
  include Materialist::Materializer

  materialize_link :zone
end

class ZoneMaterializer
  include Materialist::Materializer

  use_model :zone

  materialize :name
  materialize :code

  link :settings do
    materialize :max_login_distance_m
  end
end
```

### What

If `use_model` is not provided in a materialiser, simply skip the resource itself.