### PR TITLE
Fix: Sidekiq setter bug

### DIFF
--- a/lib/materialist/event_handler.rb
+++ b/lib/materialist/event_handler.rb
@@ -25,7 +25,7 @@ module Materialist
     end
 
     def worker
-      @_worker ||= Materialist::EventWorker.set(options.slice(:queue))
+      Materialist::EventWorker.set(options.slice(:queue))
     end
   end
 end


### PR DESCRIPTION
### Why?

Because of [this sidekiq bug](https://github.com/mperham/sidekiq/issues/3602), it is not possible to memoise the setter.

### What?

There shouldn't be a big performance penalty for not memoising it. So... remove it.

