### PR TITLE
Add support for `capture_link_href`

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,10 @@ If missing, materialist skips materialising the resource itself, but will contin
 with any other functionality -- such as `materialize_link`.
 
 #### `capture <key>, as: <column> (default: key)`
-describes mapping a resource key to database column.
+describes mapping a resource key to a database column.
+
+#### `capture_link_href <key>, as: <column>`
+describes mapping a link href (as it appears on the hateous response) to a database column.
 
 #### `link <key>`
 describes materializing from a relation of the resource. This can be nested to any depth as shown above.

--- a/spec/materialist/materializer_spec.rb
+++ b/spec/materialist/materializer_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe Materialist::Materializer do
         persist_to :foobar
         capture :name
         capture :age, as: :how_old
+        capture_link_href :city, as: :city_url
+        capture_link_href :account, as: :account_url
 
         materialize_link :city
 
@@ -99,7 +101,8 @@ RSpec.describe Materialist::Materializer do
     end
 
     class Foobar < BaseModel
-      attr_accessor :source_url, :name, :how_old, :age, :timezone, :country_tld
+      attr_accessor :source_url, :name, :how_old, :age, :timezone,
+        :country_tld, :city_url, :account_url
     end
 
     class City < BaseModel
@@ -145,6 +148,7 @@ RSpec.describe Materialist::Materializer do
       expect(inserted.how_old).to eq source_body[:age]
       expect(inserted.timezone).to eq city_body[:timezone]
       expect(inserted.country_tld).to eq country_body[:tld]
+      expect(inserted.account_url).to be_nil
     end
 
     it "materializes linked record separately in db" do


### PR DESCRIPTION
## New feature 🎉 

> #### `capture_link_href <key>, as: <column>`
> describes mapping a link href (as it appears on the hateous response) to a database column.
