### PR TITLE
RC-XXX: Allow serialisation of complex types to json

### DIFF
--- a/lib/materialist/materializer.rb
+++ b/lib/materialist/materializer.rb
@@ -177,7 +177,7 @@ module Materialist
           mapping.inject({}) do |result, m|
             case m
             when FieldMapping
-              result.tap { |r| r[m.as] = resource.body[m.key] }
+              result.tap { |r| r[m.as] = serializable_value(resource.body[m.key]) }
             when LinkMapping
               resource.body._links.include?(m.key) ?
                 result.merge(build_attributes(resource_at(resource.send(m.key).url), m.mapping || [])) :
@@ -186,6 +186,11 @@ module Materialist
               result
             end
           end
+        end
+
+        def serializable_value(value)
+          value_is_complex = [Hash, Array].any? { |complex| value.is_a?(complex) }
+          value_is_complex ? value.to_json : value
         end
 
         def resource_at(url)

--- a/lib/materialist/materializer.rb
+++ b/lib/materialist/materializer.rb
@@ -189,8 +189,8 @@ module Materialist
         end
 
         def serializable_value(value)
-          value_is_complex = [Hash, Array].any? { |complex| value.is_a?(complex) }
-          value_is_complex ? value.to_json : value
+          value_is_complex_object = value.is_a?(Hash) || value.is_a?(Array)
+          value_is_complex_object ? value.to_json : value
         end
 
         def resource_at(url)

--- a/spec/materialist/materializer_spec.rb
+++ b/spec/materialist/materializer_spec.rb
@@ -150,15 +150,6 @@ RSpec.describe Materialist::Materializer do
       expect(inserted.country_tld).to eq country_body[:tld]
     end
 
-    it "materializes record in db" do
-      expect{perform}.to change{Foobar.count}.by 1
-      inserted = Foobar.find_by(source_url: source_url)
-      expect(inserted.name).to eq source_body[:name]
-      expect(inserted.how_old).to eq source_body[:age]
-      expect(inserted.timezone).to eq city_body[:timezone]
-      expect(inserted.country_tld).to eq country_body[:tld]
-    end
-
     it "materializes linked record separately in db" do
       expect{perform}.to change{City.count}.by 1
 

--- a/spec/materialist/materializer_spec.rb
+++ b/spec/materialist/materializer_spec.rb
@@ -117,6 +117,8 @@ RSpec.describe Materialist::Materializer do
     let(:city_body) {{ _links: { country: { href: country_url }}, name: 'paris', timezone: 'Europe/Paris' }}
     let(:source_url) { 'https://service.dev/foobars/1' }
     let(:source_body) {{ _links: { city: { href: city_url }}, name: 'jack', age: 30 }}
+    let(:complex_url) { 'https://service.dev/hashes/1' }
+    let(:complex_body) {{ _links: { city: { href: city_url }}, name: { first_name: 'Mo', last_name: 'Town' }, age: [30,31,44] }}
 
     def stub_resource(url, body)
       stub_request(:get, url).to_return(
@@ -133,10 +135,20 @@ RSpec.describe Materialist::Materializer do
       stub_resource source_url, source_body
       stub_resource country_url, country_body
       stub_resource city_url, city_body
+      stub_resource complex_url, complex_body
     end
 
     let(:action) { :create }
     let(:perform) { FoobarMaterializer.perform(source_url, action) }
+
+    it "materializes record in db" do
+      expect{perform}.to change{Foobar.count}.by 1
+      inserted = Foobar.find_by(source_url: source_url)
+      expect(inserted.name).to eq source_body[:name]
+      expect(inserted.how_old).to eq source_body[:age]
+      expect(inserted.timezone).to eq city_body[:timezone]
+      expect(inserted.country_tld).to eq country_body[:tld]
+    end
 
     it "materializes record in db" do
       expect{perform}.to change{Foobar.count}.by 1
@@ -152,6 +164,17 @@ RSpec.describe Materialist::Materializer do
 
       inserted = City.find_by(source_url: city_url)
       expect(inserted.name).to eq city_body[:name]
+    end
+
+    context "when there are complex value types" do
+      let(:perform) { FoobarMaterializer.perform(complex_url, action) }
+
+      it "serialises the complex value into json" do
+        expect{perform}.to change{Foobar.count}.by 1
+        inserted = Foobar.find_by(source_url: complex_url)
+        expect(inserted.name).to eq complex_body[:name].to_json
+        expect(inserted.how_old).to eq complex_body[:age].to_json
+      end
     end
 
     context "when record already exists" do


### PR DESCRIPTION
Instead of saving the value as a string of Hashie::Mash like `<Hashie::Mash x=y, foo=bar...>` it now saves the value as JSON