### PR TITLE
Don't serialize hashes and arrays

### DIFF
--- a/lib/materialist/materializer.rb
+++ b/lib/materialist/materializer.rb
@@ -190,7 +190,7 @@ module Materialist
           mapping.inject({}) do |result, m|
             case m
             when FieldMapping
-              result.tap { |r| r[m.as] = serializable_value(resource.body[m.key]) }
+              result.tap { |r| r[m.as] = resource.body[m.key] }
             when LinkHrefMapping
               result.tap do |r|
                 if resource.body._links.include?(m.key)
@@ -205,11 +205,6 @@ module Materialist
               result
             end
           end
-        end
-
-        def serializable_value(value)
-          value_is_complex_object = value.is_a?(Hash) || value.is_a?(Array)
-          value_is_complex_object ? value.to_json : value
         end
 
         def resource_at(url)

--- a/spec/materialist/materializer_spec.rb
+++ b/spec/materialist/materializer_spec.rb
@@ -120,8 +120,6 @@ RSpec.describe Materialist::Materializer do
     let(:city_body) {{ _links: { country: { href: country_url }}, name: 'paris', timezone: 'Europe/Paris' }}
     let(:source_url) { 'https://service.dev/foobars/1' }
     let(:source_body) {{ _links: { city: { href: city_url }}, name: 'jack', age: 30 }}
-    let(:complex_url) { 'https://service.dev/hashes/1' }
-    let(:complex_body) {{ _links: { city: { href: city_url }}, name: { first_name: 'Mo', last_name: 'Town' }, age: [30,31,44] }}
 
     def stub_resource(url, body)
       stub_request(:get, url).to_return(
@@ -138,7 +136,6 @@ RSpec.describe Materialist::Materializer do
       stub_resource source_url, source_body
       stub_resource country_url, country_body
       stub_resource city_url, city_body
-      stub_resource complex_url, complex_body
     end
 
     let(:action) { :create }
@@ -159,17 +156,6 @@ RSpec.describe Materialist::Materializer do
 
       inserted = City.find_by(source_url: city_url)
       expect(inserted.name).to eq city_body[:name]
-    end
-
-    context "when there are complex value types" do
-      let(:perform) { FoobarMaterializer.perform(complex_url, action) }
-
-      it "serialises the complex value into json" do
-        expect{perform}.to change{Foobar.count}.by 1
-        inserted = Foobar.find_by(source_url: complex_url)
-        expect(inserted.name).to eq complex_body[:name].to_json
-        expect(inserted.how_old).to eq complex_body[:age].to_json
-      end
     end
 
     context "when record already exists" do


### PR DESCRIPTION
Reverts deliveroo/materialist#28

This change removes the serializing of hashes and arrays to JSON. The
reason being that this should be a concern of the application. The
benefit being that the application can choose the best method to
translate and store the data.

Note: This is potentially a breaking change and as such will require a major
version bump.

