### PR TITLE
RC-1353: Allow source key to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ class ZoneMaterializer
 
   persist_to :zone
 
+  source_key :source_id do |url|
+    /(\d+)\/?$/.match(url)[1]
+  end
+
   capture :id, as: :orderweb_id
   capture :code
   capture :name
@@ -141,6 +145,12 @@ Here is what each part of the DSL mean:
 describes the name of the active record model to be used.
 If missing, materialist skips materialising the resource itself, but will continue
 with any other functionality -- such as `materialize_link`.
+
+
+#### `source_key <column> <url_parser_block> (default: url)`
+describes the column used to persist the unique identifier parsed from the url_parser_block.
+By default the column used is `:source_url` and the original `url` is used as the identifier.
+Passing an optional block allows you to extract an identifier from the URL.
 
 #### `capture <key>, as: <column> (default: key)`
 describes mapping a resource key to a database column.
@@ -169,7 +179,7 @@ class ZoneMaterializer
 
   def my_method(record)
   end
-  
+
   def my_second_method(record)
   end
 end

--- a/lib/materialist/materializer.rb
+++ b/lib/materialist/materializer.rb
@@ -80,9 +80,9 @@ module Materialist
           __materialist_options[:model_class] = klass
         end
 
-        def source_key(key, url_parser: nil)
+        def source_key(key, &url_parser_block)
           __materialist_options[:source_key] = key
-          __materialist_options[:url_parser] = url_parser
+          __materialist_options[:url_parser] = url_parser_block
         end
 
         def after_upsert(*method_array)

--- a/spec/materialist/materializer_spec.rb
+++ b/spec/materialist/materializer_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Materialist::Materializer do
 
         persist_to :defined_source
 
-        source_key(:source_id) do |url|
+        source_key :source_id do |url|
           url.split('/').last.to_i
         end
 

--- a/spec/materialist/materializer_spec.rb
+++ b/spec/materialist/materializer_spec.rb
@@ -40,7 +40,11 @@ RSpec.describe Materialist::Materializer do
         include Materialist::Materializer
 
         persist_to :defined_source
-        source_key :source_id, url_parser: -> url { url.split('/').last.to_i }
+
+        source_key(:source_id) do |url|
+          url.split('/').last.to_i
+        end
+
         capture :name
       end
     end

--- a/spec/materialist/materializer_spec.rb
+++ b/spec/materialist/materializer_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Materialist::Materializer do
         include Materialist::Materializer
 
         persist_to :foobar
+
         capture :name
         capture :age, as: :how_old
         capture_link_href :city, as: :city_url
@@ -31,6 +32,15 @@ RSpec.describe Materialist::Materializer do
         include Materialist::Materializer
 
         persist_to :city
+        source_key :source_url
+        capture :name
+      end
+
+      class DefinedSourceMaterializer
+        include Materialist::Materializer
+
+        persist_to :defined_source
+        source_key :source_id, url_parser: -> url { url.split('/').last.to_i }
         capture :name
       end
     end
@@ -42,37 +52,49 @@ RSpec.describe Materialist::Materializer do
       end
 
       def save!
-        self.class.all[source_url] = self
+        self.class.all[source_key_value] = self
       end
 
       def destroy!
-        self.class.all.delete source_url
+        self.class.all.delete source_key_value
       end
 
       def reload
-        self.class.all[source_url]
+        self.class.all[source_key_value]
       end
 
       def actions_called
         @_actions_called ||= {}
       end
 
-      class << self
-        attr_accessor :error_to_throw_once_in_find_or_initialize_by
+      private def source_key_value
+        send(self.class.source_key_column)
+      end
 
-        def find_or_initialize_by(source_url:)
+      class << self
+        attr_accessor :error_to_throw_once_in_find_or_initialize_by,
+                      :source_key_column
+
+        def find_or_initialize_by(kv_hash)
           if(err = error_to_throw_once_in_find_or_initialize_by)
             self.error_to_throw_once_in_find_or_initialize_by = nil
             raise err
           end
 
-          (all[source_url] || self.new).tap do |record|
-            record.source_url = source_url
+          key_value = kv_hash[source_key_column]
+
+          (all[key_value] || self.new).tap do |record|
+            record.send("#{source_key_column}=", key_value)
           end
         end
 
-        def find_by(source_url:)
-          all[source_url]
+        def source_key_column
+          @source_key_column || :source_url
+        end
+
+        def find_by(kv_hash)
+          key_value = kv_hash[source_key_column]
+          all[key_value]
         end
 
         def create!(attrs)
@@ -109,6 +131,11 @@ RSpec.describe Materialist::Materializer do
       attr_accessor :source_url, :name
     end
 
+    class DefinedSource < BaseModel
+      attr_accessor :source_id, :name
+      self.source_key_column = :source_id
+    end
+
     module ActiveRecord
       class RecordNotUnique < StandardError; end
       class RecordInvalid < StandardError; end
@@ -120,6 +147,9 @@ RSpec.describe Materialist::Materializer do
     let(:city_body) {{ _links: { country: { href: country_url }}, name: 'paris', timezone: 'Europe/Paris' }}
     let(:source_url) { 'https://service.dev/foobars/1' }
     let(:source_body) {{ _links: { city: { href: city_url }}, name: 'jack', age: 30 }}
+    let(:defined_source_id) { 65 }
+    let(:defined_source_url) { "https://service.dev/defined_sources/#{defined_source_id}" }
+    let(:defined_source_body) {{ name: 'ben' }}
 
     def stub_resource(url, body)
       stub_request(:get, url).to_return(
@@ -132,10 +162,12 @@ RSpec.describe Materialist::Materializer do
     before do
       Foobar.destroy_all
       City.destroy_all
+      DefinedSource.destroy_all
 
       stub_resource source_url, source_body
       stub_resource country_url, country_body
       stub_resource city_url, city_body
+      stub_resource defined_source_url, defined_source_body
     end
 
     let(:action) { :create }
@@ -360,6 +392,50 @@ RSpec.describe Materialist::Materializer do
         it "does not materialize linked parent" do
           expect{perform}.to_not change{City.count}
         end
+      end
+    end
+
+    context "when creating a new entity based on the source_key column" do
+      let(:perform) { DefinedSourceMaterializer.perform(defined_source_url, action) }
+
+      it "creates based on source_key" do
+        expect{perform}.to change{DefinedSource.count}.by 1
+      end
+
+      it "sets the correct source key" do
+        perform
+        inserted = DefinedSource.find_by(source_id: defined_source_id)
+        expect(inserted.source_id).to eq defined_source_id
+        expect(inserted.name).to eq defined_source_body[:name]
+      end
+    end
+
+    context "when updating a new entity based on the source_key column" do
+      let(:action) { :update }
+      let!(:record) { DefinedSource.create!(source_id: defined_source_id, name: 'mo') }
+      let(:perform) { DefinedSourceMaterializer.perform(defined_source_url, action) }
+
+      it "updates based on source_key" do
+        perform
+        expect(DefinedSource.count).to eq 1
+      end
+
+      it "updates the existing record" do
+        perform
+        inserted = DefinedSource.find_by(source_id: defined_source_id)
+        expect(inserted.source_id).to eq defined_source_id
+        expect(inserted.name).to eq defined_source_body[:name]
+      end
+    end
+
+    context "when deleting an entity based on the source_key column" do
+      let(:action) { :delete }
+      let!(:record) { DefinedSource.create!(source_id: defined_source_id, name: 'mo') }
+      let(:perform) { DefinedSourceMaterializer.perform(defined_source_url, action) }
+
+      it "deletes based on source_key" do
+        perform
+        expect(DefinedSource.count).to eq 0
       end
     end
   end


### PR DESCRIPTION
Using URLs as an entity key is restrictive because it means if the URL changes it breaks all your model identities. By parsing the actual source ID from the URL we can break the tight coupling that exists.

 