### PR TITLE
Refactor configuration + Add ability to provide metrics client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ services:
   - redis-server
 rvm:
   - 2.4.0
-  - ruby-head
+  - 2.5.0
 script:
   - bundle exec rspec

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,11 @@
+## 3.0.0
+
+Breaking change:
+- `topics`, `retry` and `queue` options are now configured via `Materialist.configure` block.
+
+Features:
+- Ability to provide metrics client e.g. STATSD
+
 ## 2.3.1
 
 Fixes:

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -24,7 +24,7 @@ module Materialist
 
     class NullMetricsClient
       def self.increment(_, tags:); end
-      def self.histogram(_, tags:); end
+      def self.histogram(_, _v, tags:); end
     end
   end
 end

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -1,0 +1,29 @@
+module Materialist
+  class << self
+    def configuration
+      @configuration ||= Configuration.new
+    end
+
+    def reset_configuration!
+      @configuration = Configuration.new
+    end
+
+    def configure
+      yield(self.configuration)
+    end
+  end
+
+  class Configuration
+    attr_accessor :topics, :sidekiq_options, :metrics_client
+
+    def initialize
+      @topics = []
+      @sidekiq_options = {}
+      @metrics_client = NullMetricsClient
+    end
+
+    class NullMetricsClient
+      def self.increment(_, tags:); end
+    end
+  end
+end

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -24,6 +24,7 @@ module Materialist
 
     class NullMetricsClient
       def self.increment(_, tags:); end
+      def self.histogram(_, tags:); end
     end
   end
 end

--- a/lib/materialist.rb
+++ b/lib/materialist.rb
@@ -1,3 +1,5 @@
+require_relative './configuration'
+
 module Materialist
-  VERSION = '2.3.1'
+  VERSION = '3.0.0'
 end

--- a/lib/materialist/event_worker.rb
+++ b/lib/materialist/event_worker.rb
@@ -25,7 +25,8 @@ module Materialist
     def report_latency(topic, timestamp)
       t = (Time.now.to_f - (timestamp.to_i / 1e3)).round(1)
       Materialist.configuration.metrics_client.histogram(
-        "materialist.event_worker.latency",
+        "materialist.event_latency",
+        t,
         tags: ["topic:#{topic}"]
       )
     end

--- a/lib/materialist/event_worker.rb
+++ b/lib/materialist/event_worker.rb
@@ -10,11 +10,10 @@ module Materialist
       action = event['type'].to_sym
       timestamp = event['t']
 
-      report_latency(topic, timestamp) if timestamp
-
       materializer = "#{topic.to_s.singularize.classify}Materializer".constantize
       materializer.perform(event['url'], action)
 
+      report_latency(topic, timestamp) if timestamp
       report_stats(topic, action, :success)
     rescue
       report_stats(topic, action, :failure)

--- a/lib/materialist/event_worker.rb
+++ b/lib/materialist/event_worker.rb
@@ -7,8 +7,23 @@ module Materialist
 
     def perform(event)
       topic = event['topic']
+      action = event['type'].to_sym
       materializer = "#{topic.to_s.singularize.classify}Materializer".constantize
-      materializer.perform(event['url'], event['type'].to_sym)
+
+      materializer.perform(event['url'], action)
+      report_stats(topic, action, :success)
+    rescue
+      report_stats(topic, action, :failure)
+      raise
+    end
+
+    private
+
+    def report_stats(topic, action, kind)
+      Materialist.configuration.metrics_client.increment(
+        "materialist.event_worker.#{kind}",
+        tags: ["action:#{action}", "topic:#{topic}"]
+      )
     end
   end
 end

--- a/spec/materialist/event_worker_spec.rb
+++ b/spec/materialist/event_worker_spec.rb
@@ -55,7 +55,8 @@ RSpec.describe Materialist::EventWorker do
 
       it 'logs latency to metrics' do
         expect(metrics_client).to receive(:histogram).with(
-          "materialist.event_worker.latency",
+          "materialist.event_latency",
+          instance_of(Float),
           tags: ["topic:foobar"]
         )
         perform

--- a/spec/materialist/event_worker_spec.rb
+++ b/spec/materialist/event_worker_spec.rb
@@ -6,21 +6,42 @@ RSpec.describe Materialist::EventWorker do
     let(:source_url) { 'https://service.dev/foobars/1' }
     let(:event) {{ 'topic' => :foobar, 'url' => source_url, 'type' => 'noop' }}
     let!(:materializer_class) { FoobarMaterializer = Class.new }
+    let(:metrics_client) { double(increment: true) }
 
     before do
       allow(FoobarMaterializer).to receive(:perform)
+      Materialist.configure { |c| c.metrics_client = metrics_client }
     end
 
-    after do
-      Object.send(:remove_const, :FoobarMaterializer)
+    after { Object.send(:remove_const, :FoobarMaterializer) }
+
+    let(:perform) { subject.perform(event) }
+
+    it "calls the relevant materializer" do
+      expect(FoobarMaterializer).to receive(:perform).with(source_url, :noop)
+      perform
     end
 
-    context "when run synchronously" do
-      let(:perform) { subject.perform(event) }
+    it 'logs success to metrics' do
+      expect(metrics_client).to receive(:increment).with(
+        "materialist.event_worker.success",
+        tags: ["action:noop", "topic:foobar"]
+      )
+      perform
+    end
 
-      it "calls the relevant materializer" do
-        expect(FoobarMaterializer).to receive(:perform).with(source_url, :noop)
-        perform
+    context 'when there is an error' do
+      let(:error){ StandardError.new }
+      before do
+        expect(FoobarMaterializer).to receive(:perform).and_raise error
+      end
+
+      it 'logs failure to metrics and re-raises the error' do
+        expect(metrics_client).to receive(:increment).with(
+          "materialist.event_worker.failure",
+          tags: ["action:noop", "topic:foobar"]
+        )
+        expect{ perform }.to raise_error error
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,8 @@ RSpec.configure do |config|
   config.raise_errors_for_deprecations!
 
   config.before(:each) do
+    Materialist.reset_configuration!
+    
     # clear database
     ActiveRecord::Base.descendants.each(&:delete_all)
   end


### PR DESCRIPTION
### 3.0.0

⚠️  Breaking change:
- `topics`, `retry` and `queue` options are now configured via `Materialist.configure` block.

Features:
- Ability to provide metrics client e.g. STATSD
