### PR TITLE
Feature: Add support for enriching errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,9 @@ end
 
 - `topics` (only when using in `.subscribe`): A string array of topics to be used.  
 If not provided nothing would be materialized.
-- `sidekiq_options` (optional, default: `{ retry: 10 }`) -- See [Sidekiq docs](https://github.com/mperham/sidekiq/wiki/Advanced-Options#workers) for list of optiosn
+- `sidekiq_options` (optional, default: `{ retry: 10 }`) -- See [Sidekiq docs](https://github.com/mperham/sidekiq/wiki/Advanced-Options#workers) for list of options
 - `metrics_client` (optional) -- You can pass your `STATSD` instance
+- `notice_error` (optional) -- You can pass a lambda accepting two parameters (`exception` and `event`) -- Typical use case is to enrich error and send to NewRelic APM
 
 ### Routemaster Configuration
 
@@ -160,8 +161,8 @@ Here is what each part of the DSL mean:
 
 #### `sidekiq_options <options>`
 allows to override options for the Sidekiq job which does the materialization.
-Typically it will specify which queue to put the job on or how many times 
-should the job try to retry. These options override the options specified in 
+Typically it will specify which queue to put the job on or how many times
+should the job try to retry. These options override the options specified in
 `Materialist.configuration.sidekiq_options`.
 
 #### `persist_to <model_name>`

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,8 +1,13 @@
+## next
+
+Features:
+- Add support for providing `notice_error` on configuration.
+
 ## 3.2.0
 
 Features:
 - For linked resources specified by `link` an option to `enable_caching` can now be explicitly set. This
-tells Routemaster to use or not use the drain cache. 
+tells Routemaster to use or not use the drain cache.
 
 ## 3.1.0
 
@@ -12,8 +17,8 @@ Features:
 
 Notes:
 
-Materialist::EventWorker has been moved to Materialist::Workers::Event, but the original has 
-been left there for backwards compatibility. It will be removed in a later major release. 
+Materialist::EventWorker has been moved to Materialist::Workers::Event, but the original has
+been left there for backwards compatibility. It will be removed in a later major release.
 
 ## 3.0.0
 

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -14,12 +14,13 @@ module Materialist
   end
 
   class Configuration
-    attr_accessor :topics, :sidekiq_options, :metrics_client
+    attr_accessor :topics, :sidekiq_options, :metrics_client, :notice_error
 
     def initialize
       @topics = []
       @sidekiq_options = {}
       @metrics_client = NullMetricsClient
+      @notice_error = nil
     end
 
     class NullMetricsClient

--- a/lib/materialist/workers/event.rb
+++ b/lib/materialist/workers/event.rb
@@ -16,8 +16,9 @@ module Materialist
 
         report_latency(topic, timestamp) if timestamp
         report_stats(topic, action, :success)
-      rescue
+      rescue Exception => exception
         report_stats(topic, action, :failure)
+        notice_error(exception, event)
         raise
       end
 
@@ -37,6 +38,11 @@ module Materialist
           "materialist.event_worker.#{kind}",
           tags: ["action:#{action}", "topic:#{topic}"]
         )
+      end
+
+      def notice_error(exception, event)
+        return unless handler = Materialist.configuration.notice_error
+        handler.call(exception, event)
       end
     end
   end

--- a/spec/materialist/workers/event_spec.rb
+++ b/spec/materialist/workers/event_spec.rb
@@ -48,6 +48,20 @@ RSpec.describe Materialist::Workers::Event do
         )
         expect{ perform }.to raise_error error
       end
+
+      context 'when there is notice_error configured' do
+        let(:configuration) { Materialist::Configuration.new.tap{ |c| c.notice_error = func } }
+        let(:func) { double }
+
+        before do
+          allow(Materialist).to receive(:configuration).and_return configuration
+        end
+
+        it 'calls the configured notice_error func' do
+          expect(func).to receive(:call).with(error, event)
+          expect{ perform }.to raise_error error
+        end
+      end
     end
 
     context 'when event has a timestamp' do


### PR DESCRIPTION
### Why

Currently materialist worker errors appearing on new relic are blank and it's impossible to identify what event they were raised by.

### What

Allow consumers to provide a `notice_error` function to do custom error handling:

```ruby
Materialist.configure do |config|
  config.notice_error = ->(exception, event) do
    NewRelic::Agent.notice_error(exception, custom_params: event)
  end
end
```