### PR TITLE
LOG-XXX Accept nested keys for capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Materialist.configure do |config|
 end
 ```
 
-- `topics` (only when using in `.subscribe`): A string array of topics to be used.  
+- `topics` (only when using in `.subscribe`): A string array of topics to be used.
 If not provided nothing would be materialized.
 - `sidekiq_options` (optional, default: `{ retry: 10 }`) -- See [Sidekiq docs](https://github.com/mperham/sidekiq/wiki/Advanced-Options#workers) for list of options
 - `api_client` (optional) -- You can pass your `Routemaster::APIClient` instance
@@ -162,6 +162,7 @@ class ZoneMaterializer
   capture :id, as: :orderweb_id
   capture :code
   capture :name
+  capture %i[location, latitude], as: :current_latitude
 
   link :city do
     capture :tz_name, as: :timezone
@@ -194,8 +195,10 @@ describes the column used to persist the unique identifier parsed from the url_p
 By default the column used is `:source_url` and the original `url` is used as the identifier.
 Passing an optional block allows you to extract an identifier from the URL.
 
-#### `capture <key>, as: <column> (default: key)`
-describes mapping a resource key to a database column.
+#### `capture <key> || [<keys>], as: <column> (default: key || keys.last)`
+describes mapping a resource key to a database column. An array of keys can be provided to extract
+a nested value. The default column name is the key name or the last key name when an array is
+provided.
 
 #### `capture_link_href <key>, as: <column>`
 describes mapping a link href (as it appears on the hateous response) to a database column.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,10 @@
 
 _description of next release_
 
+## 3.6.0
+
+- Add support for passing array of key values to DSL `capture` method for nested value extraction.
+
 ## 3.5.0
 
 - Add support for providing an `Routemaster::APIClient` instance as part of configuration

--- a/lib/materialist/materializer/internals/dsl.rb
+++ b/lib/materialist/materializer/internals/dsl.rb
@@ -6,7 +6,7 @@ module Materialist
           __materialist_options[:links_to_materialize][key] = { topic: topic }
         end
 
-        def capture(key, as: key)
+        def capture(key, as: [key].flatten.last)
           __materialist_dsl_mapping_stack.last << FieldMapping.new(key: key, as: as)
         end
 

--- a/lib/materialist/materializer/internals/field_mapping.rb
+++ b/lib/materialist/materializer/internals/field_mapping.rb
@@ -8,7 +8,7 @@ module Materialist
         end
 
         def map(resource)
-          { @as => resource.dig(@key) }
+          { @as => resource.dig(*[@key].flatten) }
         end
       end
     end

--- a/lib/materialist/version.rb
+++ b/lib/materialist/version.rb
@@ -1,3 +1,3 @@
 module Materialist
-  VERSION = '3.5.0'
+  VERSION = '3.6.0'
 end

--- a/spec/materialist/materializer/internals/field_mapping_spec.rb
+++ b/spec/materialist/materializer/internals/field_mapping_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+require 'materialist/materializer/internals'
+
+include Materialist::Materializer::Internals
+
+RSpec.describe Materialist::Materializer::Internals::FieldMapping, type: :internals do
+  describe '#map' do
+    let(:resource) do
+      {
+        a: 1,
+        b: {
+          c: 2,
+          d: {
+            e: 3
+          }
+        }
+      }
+    end
+    let(:map) { described_class.new(key: key, as: :z).map(resource) }
+
+    context 'when a single key is passed' do
+      let(:key) { :a }
+      let(:expected_result) { { z: 1 } }
+
+      it { expect(map).to eq(expected_result) }
+    end
+
+    context 'when a single key is passed that does not exist' do
+      let(:key) { :c }
+      let(:expected_result) { { z: nil } }
+
+      it { expect(map).to eq(expected_result) }
+    end
+
+    context 'when an array of keys is passed' do
+      let(:key) { [:b, :d] }
+      let(:expected_result) { { z: { e: 3 } } }
+
+      it { expect(map).to eq(expected_result) }
+    end
+
+    context 'when an array of keys that does not exist is passed' do
+      let(:key) { [:b, :d, :f] }
+      let(:expected_result) { { z: nil } }
+
+      it { expect(map).to eq(expected_result) }
+    end
+  end
+end


### PR DESCRIPTION
Allow an array of key names to be passed to `capture` to allow deep extraction of a value from the JSON.