### PR TITLE
Introducing `before_upsert_with_payload` hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Materialist.configure do |config|
 end
 ```
 
-- `topics` (only when using in `.subscribe`): A string array of topics to be used.  
+- `topics` (only when using in `.subscribe`): A string array of topics to be used.
 If not provided nothing would be materialized.
 - `sidekiq_options` (optional, default: `{ retry: 10 }`) -- See [Sidekiq docs](https://github.com/mperham/sidekiq/wiki/Advanced-Options#workers) for list of options
 - `api_client` (optional) -- You can pass your `Routemaster::APIClient` instance
@@ -240,6 +240,24 @@ class ZoneMaterializer
 
   def my_second_method(record)
   end
+end
+```
+
+#### `before_upsert_with_payload <method> (, <method>(, ...))`
+describes the name of the instance method(s) to be invoked before a record is
+materialized, with the record as it exists in the database, or nil if it has
+not been created yet. The function will get as a second argument the `payload`
+of the HTTP response, this can be used to add additional information/persist
+other objects.
+
+
+```ruby
+class ZoneMaterializer
+  include Materialist::Materializer
+
+  before_upsert_with_payload :my_method
+
+  def my_method(record, payload); end
 end
 ```
 

--- a/lib/materialist/materializer/internals/dsl.rb
+++ b/lib/materialist/materializer/internals/dsl.rb
@@ -43,6 +43,15 @@ module Materialist
           __materialist_options[:url_parser] = url_parser_block
         end
 
+        # This method is meant to be used for cases when the application needs
+        # to have access to the `payload` that is returned on the HTTP call.
+        # Such an example would be if the application logic requires all
+        # relationships to be present before the `resource` is saved in the
+        # database. Introduced in https://github.com/deliveroo/materialist/pull/47
+        def before_upsert_with_payload(*method_array)
+          __materialist_options[:before_upsert_with_payload] = method_array
+        end
+
         def before_upsert(*method_array)
           __materialist_options[:before_upsert] = method_array
         end

--- a/materialist.gemspec
+++ b/materialist.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = %w(lib)
 
   spec.add_runtime_dependency 'sidekiq', '>= 5.0'
-  spec.add_runtime_dependency 'activesupport'
+  spec.add_runtime_dependency 'activesupport', '< 6.0'
   spec.add_runtime_dependency 'routemaster-drain', '>= 3.0'
 
   spec.add_development_dependency 'activerecord'

--- a/spec/materialist/materializer_spec.rb
+++ b/spec/materialist/materializer_spec.rb
@@ -199,7 +199,12 @@ RSpec.describe Materialist::Materializer::Internals::Materializer do
 
           persist_to :foobar
           before_upsert :before_hook
+          before_upsert_with_payload :before_hook_with_payload
           after_upsert :after_hook
+
+          def before_hook_with_payload(entity, payload)
+            self.actions_called[:before_hook_with_payload] = true
+          end
 
           def before_hook(entity); self.actions_called[:before_hook] = true; end
           def after_hook(entity); self.actions_called[:after_hook] = true; end
@@ -209,6 +214,11 @@ RSpec.describe Materialist::Materializer::Internals::Materializer do
       %i(create update noop).each do |action_name|
         context "when action is :#{action_name}" do
           let(:action) { action_name }
+
+          it "calls before_upsert_with_payload method" do
+            expect{ perform }.to change { actions_called[:before_hook_with_payload] }
+          end
+
           it "calls before_upsert method" do
             expect{ perform }.to change { actions_called[:before_hook] }
           end
@@ -225,7 +235,15 @@ RSpec.describe Materialist::Materializer::Internals::Materializer do
 
                 persist_to :foobar
                 before_upsert :before_hook, :before_hook2
+                before_upsert_with_payload :before_hook_with_payload, :before_hook_with_payload2
                 after_upsert :after_hook, :after_hook2
+
+                def before_hook_with_payload(entity, payload)
+                  self.actions_called[:before_hook_with_payload] = true
+                end
+                def before_hook_with_payload2(entity, payload)
+                  self.actions_called[:before_hook_with_payload2] = true
+                end
 
                 def before_hook(entity); self.actions_called[:before_hook] = true; end
                 def before_hook2(entity); self.actions_called[:before_hook2] = true; end
@@ -239,6 +257,8 @@ RSpec.describe Materialist::Materializer::Internals::Materializer do
                                .and change { actions_called[:before_hook2] }
                                .and change { actions_called[:after_hook] }
                                .and change { actions_called[:after_hook2] }
+                               .and change { actions_called[:before_hook_with_payload] }
+                               .and change { actions_called[:before_hook_with_payload2] }
             end
           end
         end


### PR DESCRIPTION
This hook will allow applications to have access to both the resource
that is being materialized as well as the `payload`. This allows
applications to have custom loading logic for relationship elements. For
example, in `rider-api` we want to persist **deliveries** before we
persist `pickup` objects. This hook allows us to have access to the
`href` of deliveries and fetch them using the usual `materialist` flow,
but ensure that when application logic is execute we have all of the
relationships in place.