### PR TITLE
RPE-XXX: Fix Rails 6 deprecation warning

### DIFF
--- a/lib/materialist/materializer/internals/materializer.rb
+++ b/lib/materialist/materializer/internals/materializer.rb
@@ -62,7 +62,7 @@ module Materialist
           model_class.find_or_initialize_by(source_lookup(url, resource)).tap do |entity|
             send_messages(before_upsert, entity) unless before_upsert.nil?
             before_upsert_with_payload&.each { |m| instance.send(m, entity, resource) }
-            entity.update_attributes!(attributes)
+            entity.update!(attributes)
           end
         end
 


### PR DESCRIPTION
Rails 6 deprecates update_attributes and update_attributes! in favour of update and update!
Rails 6.0 only displays deprecation warning. The deprecated methods are removed from Rails 6.1